### PR TITLE
fix: webpack version

### DIFF
--- a/package.json
+++ b/package.json
@@ -38,7 +38,7 @@
     "sass-loader": "^7.0.1",
     "style-loader": "^0.21.0",
     "uglifyjs-webpack-plugin": "^1.2.5",
-    "webpack": "^4.16.2",
+    "webpack": "4.19.0",
     "webpack-bundle-analyzer": "^2.11.1",
     "webpack-cli": "^2.0.15",
     "webpack-dev-server": "^3.1.3",


### PR DESCRIPTION
Updated webpack version to fix this issue
`(base) administrator@dolap:~/Documents/trail/React-Chat$ yarn start
yarn run v1.12.3
$ webpack-dev-server --mode development --open --hot
/home/administrator/Documents/trail/React-Chat/node_modules/webpack-cli/bin/config-yargs.js:89
				describe: optionsSchema.definitions.output.properties.path.description,
				                                           ^

TypeError: Cannot read property 'properties' of undefined
    at module.exports (/home/administrator/Documents/trail/React-Chat/node_modules/webpack-cli/bin/config-yargs.js:89:48)
    at Object.<anonymous> (/home/administrator/Documents/trail/React-Chat/node_modules/webpack-dev-server/bin/webpack-dev-server.js:65:25)
    at Module._compile (internal/modules/cjs/loader.js:999:30)
    at Object.Module._extensions..js (internal/modules/cjs/loader.js:1027:10)
    at Module.load (internal/modules/cjs/loader.js:863:32)
    at Function.Module._load (internal/modules/cjs/loader.js:708:14)
    at Function.executeUserEntryPoint [as runMain] (internal/modules/run_main.js:60:12)
    at internal/main/run_main_module.js:17:47`